### PR TITLE
Further performance improvements for log collection.

### DIFF
--- a/clingwrap/examples/openstack-kolla-ansible.cwd
+++ b/clingwrap/examples/openstack-kolla-ansible.cwd
@@ -112,9 +112,17 @@
 
     - name: Docker logs for ${item} container
       type: shell
-      command: docker logs --tail 10000 ${item}
+      command: docker logs --tail 2000 ${item}
       destination: _commands/docker-${item}-logs
+    "
+    done
 
+- name: Container pip lists (running containers only)
+  type: shell_emitter
+  command: |
+    for item in `docker ps --format '{{ .Names }}'`
+    do
+      echo "
     - name: pip list for ${item} container system pip
       type: shell
       command: docker exec -t ${item} pip list

--- a/clingwrap/main.py
+++ b/clingwrap/main.py
@@ -145,7 +145,8 @@ class ShellEmitterJob(Job):
     def execute(self):
         self.log('Executing')
         try:
-            stdout, stderr = processutils.execute(self.command, shell=True)
+            stdout, stderr = processutils.execute(
+                self.command, shell=True, timeout=60)
             if stdout:
                 self.log(f'Received stdout while generating jobs: {stdout}')
             if stderr:


### PR DESCRIPTION
Add a 60-second timeout to ShellEmitterJob to prevent indefinite hangs during job generation. Split container pip list collection to only run on running containers (docker exec fails on stopped containers). Reduce docker logs tail from 10000 to 2000 lines to reduce data volume.

Prompt: Implement recommendations 1, 2, and 3 in clingwrap to fix CI log collection timeouts:
  1. Add timeout to ShellEmitterJob
  2. Filter docker exec to running containers only
  3. Reduce docker logs tail size