### PR TITLE
Add documentation directory and architecture files.

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,85 @@
+# AI Agent Instructions for Clingwrap
+
+This document provides guidance for AI agents working on the clingwrap codebase.
+
+## Project Overview
+
+Clingwrap is a debugging information collection tool that bundles system state
+data into a zip file for later analysis. It is a relatively simple project with
+a single main module.
+
+## Key Files
+
+| File | Purpose |
+|------|---------|
+| `clingwrap/main.py` | Core implementation - all job classes and CLI |
+| `pyproject.toml` | Project metadata, dependencies, and build configuration |
+| `clingwrap/examples/*.cwd` | Example configuration files |
+| `docs/` | Documentation directory |
+
+## Architecture
+
+The codebase uses a job-based architecture:
+
+1. **Job base class** - Common functionality for all job types
+2. **FileJob** - Copies individual files to the ZIP archive
+3. **DirectoryJob** - Recursively processes directories, yielding FileJobs
+4. **ShellJob** - Executes shell commands with timeout
+5. **ShellEmitterJob** - Runs scripts that generate additional job definitions
+
+Jobs are processed depth-first to minimize memory usage.
+
+## Code Style
+
+- Python 3.7+ compatible
+- Line length: 120 characters (flake8 configuration)
+- Single quotes for strings except docstrings
+- Use oslo.concurrency for process execution
+
+## Testing
+
+Run tests with:
+
+```bash
+tox -e py38
+```
+
+Run linting with:
+
+```bash
+tox -e flake8
+```
+
+## Common Tasks
+
+### Adding a New Command Type
+
+1. Create a new class inheriting from `Job` in `clingwrap/main.py`
+2. Implement `__init__` calling `super().__init__(**kwargs)`
+3. Override `execute()` or `_execute_inner()` as appropriate
+4. Add the class to `JOB_MAP` dictionary
+5. Document the new type in `docs/command-types.md`
+
+### Adding a New Built-in Example
+
+1. Create a new `.cwd` file in `clingwrap/examples/`
+2. Document it in `docs/examples.md`
+3. Update `docs/index.md` to list the new example
+
+## Dependencies
+
+Key dependencies:
+
+- `click` - CLI framework
+- `pyyaml` - Configuration parsing
+- `oslo.concurrency` - Process execution with timeouts
+
+## Documentation
+
+Documentation is in `docs/` as Markdown files:
+
+- `index.md` - Main entry point
+- `installation.md` - Installation instructions
+- `configuration.md` - Configuration file format
+- `command-types.md` - All command types
+- `examples.md` - Example configurations

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,0 +1,204 @@
+# Clingwrap Architecture
+
+## Overview
+
+Clingwrap is a debugging information collection tool that processes a YAML
+configuration file to gather system state into a compressed ZIP archive.
+
+## High-Level Architecture
+
+```
++-------------------+     +------------------+     +------------------+
+|                   |     |                  |     |                  |
+|  Configuration    |---->|  Job Processing  |---->|  ZIP Archive     |
+|  (YAML file)      |     |  Engine          |     |  Output          |
+|                   |     |                  |     |                  |
++-------------------+     +------------------+     +------------------+
+                                 |
+                                 v
+                    +------------------------+
+                    |                        |
+                    |  Job Classes           |
+                    |  - FileJob             |
+                    |  - DirectoryJob        |
+                    |  - ShellJob            |
+                    |  - ShellEmitterJob     |
+                    |                        |
+                    +------------------------+
+```
+
+## Components
+
+### CLI Layer (`clingwrap/main.py`)
+
+The CLI uses Click framework with a single command group:
+
+- `clingwrap gather` - Main command to collect debugging information
+
+Options:
+- `--target` - Configuration file or built-in example name
+- `--output` - Output ZIP file path
+
+### Configuration Loading
+
+Configuration can be loaded from three sources:
+
+1. **File path** - Full path to a `.cwd` file
+2. **Built-in example** - Name of a shipped example (loaded via
+   `importlib.resources`)
+3. **Standard input** - YAML piped via stdin
+
+### Job System
+
+All jobs inherit from the `Job` base class:
+
+```
+Job (base class)
+├── FileJob          - Copy single file
+├── DirectoryJob     - Recursively copy directory (yields FileJobs)
+├── ShellJob         - Execute shell command
+└── ShellEmitterJob  - Generate jobs dynamically
+```
+
+#### Job Base Class
+
+Provides common functionality:
+
+- Random job ID for tracking
+- Logging (dual output: console and log file)
+- Reference to ZIP archive for writing
+- Basic `execute()` method that calls `_execute_inner()`
+
+#### FileJob
+
+Copies a single file to the ZIP archive:
+
+- Uses streaming (`zipfile.write()`) for memory efficiency
+- Handles missing files gracefully
+- Captures exceptions with error details
+
+#### DirectoryJob
+
+Recursively processes a directory:
+
+- Walks directory tree with `os.walk()`
+- Yields FileJob dictionaries for each file
+- Supports exclusion patterns via regex
+- Processing is depth-first for memory efficiency
+
+#### ShellJob
+
+Executes shell commands:
+
+- Uses `oslo_concurrency.processutils.execute()`
+- 30-second timeout per command
+- Captures stdout, stderr, and exceptions
+- Formats output with command header
+
+#### ShellEmitterJob
+
+Generates jobs dynamically:
+
+- Runs shell script with 60-second timeout
+- Parses stdout as YAML to get job definitions
+- Yields jobs for immediate processing
+- Useful for iterating over discovered objects
+
+### Processing Engine
+
+Jobs are processed depth-first:
+
+```python
+def process_job(kwargs):
+    job = JOB_MAP.get(kwargs['type'])(**kwargs)
+    for newjob in job.execute():
+        process_job(newjob)  # Recursive, depth-first
+```
+
+This approach:
+
+- Minimizes memory usage (no job queue accumulation)
+- Processes generated jobs immediately
+- Handles arbitrarily deep job hierarchies
+
+### Output Format
+
+The ZIP archive contains:
+
+```
+output.zip
+├── _commands/          # Shell command outputs
+│   ├── uname
+│   ├── ip-link
+│   └── ...
+├── etc/                # Collected config files
+│   ├── hosts
+│   ├── os-release
+│   └── apache2/
+├── var/                # Collected log files
+│   └── log/
+│       └── syslog
+├── srv/                # Application data
+│   └── ...
+└── clingwrap.log       # Execution log
+```
+
+## Performance Considerations
+
+### Memory Efficiency
+
+- FileJob uses `zipfile.write()` for streaming (not `writestr()`)
+- DirectoryJob yields jobs instead of accumulating
+- Depth-first processing prevents queue growth
+
+### Timeouts
+
+- Shell commands: 30 seconds
+- Shell emitters: 60 seconds
+
+### Large Collections
+
+For large log collections (e.g., Docker logs), configurations should use
+`--tail` or similar limiting options to avoid excessive data.
+
+## Error Handling
+
+- Missing files: Logged and placeholder written
+- File read errors: Exception captured in output
+- Shell command failures: Exception captured with stdout/stderr
+- Shell emitter failures: Exception logged, processing continues
+
+All errors are non-fatal - clingwrap continues collecting other data.
+
+## Configuration Format
+
+YAML with list of command dictionaries:
+
+```yaml
+---
+- name: Human-readable description
+  type: file|directory|shell|shell_emitter
+  source: /path/to/source        # for file/directory
+  command: shell command         # for shell/shell_emitter
+  destination: path/in/zip       # where to store output
+  exclude: regex-pattern         # optional, for directory
+```
+
+## Dependencies
+
+| Package | Purpose |
+|---------|---------|
+| `click` | CLI framework |
+| `pyyaml` | YAML parsing |
+| `oslo.concurrency` | Process execution with timeouts |
+| `shakenfist-utilities` | Shared utilities |
+
+## Future Considerations
+
+Potential enhancements:
+
+- Parallel job execution (currently sequential)
+- Progress reporting for large collections
+- Compression level configuration
+- Remote collection (SSH)
+- Incremental/differential collection

--- a/README.md
+++ b/README.md
@@ -6,6 +6,25 @@ a system and stores that information in a zip file for later analysis. It was
 originally implemented for the Shaken Fist (https://shakenfist.com) project, but is
 more generally useful than that.
 
+For comprehensive documentation, see the [docs/](docs/) directory or start with
+the [documentation index](docs/index.md).
+
+## Quick Start
+
+Install clingwrap:
+
+```bash
+pip install clingwrap
+```
+
+Run with a built-in example:
+
+```bash
+clingwrap gather --target shakenfist-ci-failure --output debug.zip
+```
+
+## Configuration
+
 Clingwrap takes a configuration file (see examples/shakenfist-ci-failure.cwd for an
 example), and processes the list of commands in that file to produce the zip file
 of debugging output. The commands are specified in a simple YAML format, where

--- a/docs/command-types.md
+++ b/docs/command-types.md
@@ -1,0 +1,306 @@
+# Command Types
+
+Clingwrap supports four command types for collecting different kinds of
+information.
+
+## File Commands
+
+Copy individual files to the output ZIP.
+
+### Syntax
+
+```yaml
+- name: Description of the file
+  type: file
+  source: /path/to/source/file
+  destination: path/in/zip
+```
+
+### Fields
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `name` | Yes | Human-readable description |
+| `type` | Yes | Must be `file` |
+| `source` | Yes | Absolute path to the source file |
+| `destination` | Yes | Path within the output ZIP |
+
+### Behavior
+
+- If the source file exists, it is copied to the ZIP using streaming (memory
+  efficient)
+- If the source file is missing, a placeholder is written:
+  `--- file /path/to/file was absent ---`
+- If an error occurs reading the file, the error is captured:
+  `--- file /path/to/file exception: <error> ---`
+
+### Example
+
+```yaml
+- name: System hosts file
+  type: file
+  source: /etc/hosts
+  destination: etc/hosts
+
+- name: Syslog
+  type: file
+  source: /var/log/syslog
+  destination: var/log/syslog
+```
+
+## Directory Commands
+
+Recursively copy all files in a directory hierarchy.
+
+### Syntax
+
+```yaml
+- name: Description of the directory
+  type: directory
+  source: /path/to/source/directory
+  destination: path/in/zip
+  exclude: "optional-regex-pattern"
+```
+
+### Fields
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `name` | Yes | Human-readable description |
+| `type` | Yes | Must be `directory` |
+| `source` | Yes | Absolute path to the source directory |
+| `destination` | Yes | Base path within the output ZIP |
+| `exclude` | No | Regular expression pattern for files to skip |
+
+### Behavior
+
+- Walks the directory tree recursively
+- Creates a file job for each file found
+- Files matching the `exclude` pattern are skipped
+- Processes files depth-first for memory efficiency
+
+### Exclude Pattern
+
+The `exclude` field accepts a Python regular expression. Files whose full path
+matches the pattern are skipped.
+
+Examples:
+
+```yaml
+# Skip disk device files
+exclude: "([hsv]d[ac-z]|nvme[0-9])"
+
+# Skip lock files
+exclude: ".*\\.lock"
+
+# Skip backup files
+exclude: ".*~$"
+```
+
+### Example
+
+```yaml
+- name: Apache configuration
+  type: directory
+  source: /etc/apache2
+  destination: etc/apache2
+
+- name: Instance data (excluding disk images)
+  type: directory
+  source: /srv/shakenfist/instances
+  destination: srv/shakenfist/instances
+  exclude: "([hsv]d[ac-z]|nvme[0-9]|sc-.*)"
+```
+
+## Shell Commands
+
+Execute shell commands and capture their output.
+
+### Syntax
+
+```yaml
+- name: Description of the command
+  type: shell
+  command: shell command to execute
+  destination: _commands/output-name
+```
+
+### Fields
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `name` | Yes | Human-readable description |
+| `type` | Yes | Must be `shell` |
+| `command` | Yes | Shell command or script to execute |
+| `destination` | Yes | Path within the output ZIP |
+
+### Behavior
+
+- Commands are executed in a shell with a 30-second timeout
+- Both stdout and stderr are captured
+- Output format includes the command and separated stdout/stderr sections
+- Exceptions are captured and included in the output
+
+### Output Format
+
+```
+# <command>
+
+----- stdout -----
+<stdout content>
+
+----- stderr -----
+<stderr content>
+```
+
+If an exception occurs:
+
+```
+# <command>
+
+----- stdout -----
+
+----- stderr -----
+
+----- exception -----
+<exception details>
+```
+
+### Multi-line Scripts
+
+The `command` field supports multi-line scripts using YAML block scalars:
+
+```yaml
+- name: Complex diagnostics
+  type: shell
+  command: |
+    echo "System Info"
+    uname -a
+    echo ""
+    echo "Memory Info"
+    free -h
+  destination: _commands/system-info
+```
+
+### Example
+
+```yaml
+- name: Kernel version
+  type: shell
+  command: uname -a
+  destination: _commands/uname
+
+- name: Network interfaces
+  type: shell
+  command: ip link
+  destination: _commands/ip-link
+
+- name: Installed packages
+  type: shell
+  command: dpkg -l
+  destination: _commands/dpkg
+```
+
+## Shell Emitter Commands
+
+Run shell scripts that dynamically generate additional commands. This is
+powerful for discovering objects at runtime and creating jobs for each.
+
+### Syntax
+
+```yaml
+- name: Description
+  shell_emitter: |
+    script that outputs YAML command definitions
+```
+
+Or with explicit type:
+
+```yaml
+- name: Description
+  type: shell_emitter
+  command: |
+    script that outputs YAML command definitions
+```
+
+### Fields
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `name` | Yes | Human-readable description |
+| `type` | Yes | Must be `shell_emitter` |
+| `command` | Yes | Shell script that outputs YAML |
+
+Note: `shell_emitter` commands do not have a `destination` field - they
+generate other commands that have destinations.
+
+### Behavior
+
+- Script is executed with a 60-second timeout
+- Script stdout must be valid YAML containing command definitions
+- Generated commands are processed immediately (depth-first)
+- Useful for iterating over dynamic lists (containers, namespaces, etc.)
+
+### Output Format
+
+The script must output valid YAML command definitions. Each generated command
+should be a complete command definition with all required fields.
+
+### Example: Network Namespaces
+
+Discover and collect information from all network namespaces:
+
+```yaml
+- name: Network namespaces
+  type: shell_emitter
+  command: |
+    for item in `find /var/run/netns -type f | sed 's/.*\///'`
+    do
+      echo "
+    - name: Network interfaces (namespace ${item})
+      type: shell
+      command: ip netns exec ${item} ip link
+      destination: _commands/netns-${item}/ip-link
+
+    - name: Network routes (namespace ${item})
+      type: shell
+      command: ip netns exec ${item} ip route
+      destination: _commands/netns-${item}/ip-route
+    "
+    done
+```
+
+### Example: Docker Containers
+
+Collect information from all running Docker containers:
+
+```yaml
+- name: Container inspection
+  type: shell_emitter
+  command: |
+    for item in `docker ps --all --format '{{ .Names }}'`
+    do
+      echo "
+    - name: Inspect ${item} container
+      type: shell
+      command: docker inspect ${item}
+      destination: _commands/docker-${item}-inspect
+
+    - name: Docker logs for ${item} container
+      type: shell
+      command: docker logs --tail 2000 ${item}
+      destination: _commands/docker-${item}-logs
+    "
+    done
+```
+
+### Tips for Shell Emitters
+
+1. **Quote YAML properly**: Be careful with indentation and quoting in the
+   generated YAML
+2. **Handle empty results**: If the loop produces no output, that's fine -
+   no jobs will be generated
+3. **Use echo with heredoc-style output**: The example pattern with echo and
+   embedded YAML works well
+4. **Limit output**: For log collection, use `--tail` or similar to avoid
+   collecting excessive data

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,158 @@
+# Configuration
+
+Clingwrap uses YAML configuration files to define what information to collect.
+These files have the `.cwd` extension by convention.
+
+## Configuration File Format
+
+A configuration file is a YAML document containing a list of commands:
+
+```yaml
+---
+- name: Descriptive name for the command
+  type: shell
+  command: uname -a
+  destination: _commands/uname
+```
+
+Each command in the list is a dictionary with the following common fields:
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `name` | Yes | Human-readable description of what this command collects |
+| `type` | Yes | Command type: `file`, `directory`, `shell`, or `shell_emitter` |
+| `destination` | Varies | Path within the output ZIP file (not required for `shell_emitter`) |
+
+Additional fields depend on the command type. See
+[Command Types](command-types.md) for details.
+
+## Destination Paths
+
+The `destination` field specifies where collected data is stored in the output
+ZIP file:
+
+- **Shell command outputs**: By convention, store in `_commands/` directory
+- **Files and directories**: Mirror the source path (e.g., `/etc/hosts` becomes
+  `etc/hosts`)
+
+Examples:
+
+```yaml
+# Shell output goes to _commands/
+- name: Kernel version
+  type: shell
+  command: uname -a
+  destination: _commands/uname
+
+# File mirrors source path structure
+- name: System hosts file
+  type: file
+  source: /etc/hosts
+  destination: etc/hosts
+
+# Directory mirrors source structure
+- name: Apache configuration
+  type: directory
+  source: /etc/apache2
+  destination: etc/apache2
+```
+
+## Loading Configuration
+
+Clingwrap can load configuration from three sources:
+
+### 1. File Path
+
+Specify the full path to a configuration file:
+
+```bash
+clingwrap gather --target /path/to/config.cwd --output debug.zip
+```
+
+### 2. Built-in Example Name
+
+Use the name of a shipped example (without path or extension):
+
+```bash
+clingwrap gather --target shakenfist-ci-failure --output debug.zip
+```
+
+Available built-in examples:
+
+- `shakenfist-ci-failure` - Shaken Fist CI failure diagnostics
+- `openstack-kolla-ansible` - OpenStack Kolla-Ansible diagnostics
+
+### 3. Standard Input
+
+Pipe configuration via stdin (omit `--target`):
+
+```bash
+cat config.cwd | clingwrap gather --output debug.zip
+```
+
+Or use a heredoc:
+
+```bash
+clingwrap gather --output debug.zip << 'EOF'
+---
+- name: Kernel version
+  type: shell
+  command: uname -a
+  destination: _commands/uname
+EOF
+```
+
+## Best Practices
+
+### Organizing Commands
+
+Group related commands together and use descriptive names:
+
+```yaml
+# System information
+- name: Kernel version and architecture
+  type: shell
+  command: uname -a
+  destination: _commands/uname
+
+- name: OS release information
+  type: file
+  source: /etc/os-release
+  destination: etc/os-release
+
+# Network diagnostics
+- name: Network interfaces
+  type: shell
+  command: ip link
+  destination: _commands/ip-link
+```
+
+### Handling Missing Files
+
+Clingwrap gracefully handles missing files - it logs the absence and continues.
+This means you can include commands for files that may not exist on all systems:
+
+```yaml
+# These will be skipped if not present
+- name: syslog
+  type: file
+  source: /var/log/syslog
+  destination: var/log/syslog
+
+- name: messages (RedHat systems)
+  type: file
+  source: /var/log/messages
+  destination: var/log/messages
+```
+
+### Using Exclusion Patterns
+
+For directory commands, use `exclude` to skip certain files:
+
+```yaml
+- name: Instance data (excluding disk images)
+  type: directory
+  source: /srv/instances
+  destination: srv/instances
+  exclude: "([hsv]d[ac-z]|nvme[0-9])"
+```

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -1,0 +1,317 @@
+# Examples
+
+This document provides example configurations for various use cases.
+
+## Basic System Diagnostics
+
+A minimal configuration for basic system information:
+
+```yaml
+---
+- name: Kernel version and architecture
+  type: shell
+  command: uname -a
+  destination: _commands/uname
+
+- name: OS release information
+  type: file
+  source: /etc/os-release
+  destination: etc/os-release
+
+- name: Hostname
+  type: shell
+  command: hostname -f
+  destination: _commands/hostname
+
+- name: Running processes
+  type: shell
+  command: ps -aux
+  destination: _commands/ps-aux
+
+- name: System logs
+  type: file
+  source: /var/log/syslog
+  destination: var/log/syslog
+```
+
+## Network Diagnostics
+
+Collect comprehensive network information:
+
+```yaml
+---
+- name: Network interfaces
+  type: shell
+  command: ip link
+  destination: _commands/ip-link
+
+- name: Network addresses
+  type: shell
+  command: ip addr
+  destination: _commands/ip-addr
+
+- name: Routing table
+  type: shell
+  command: ip route
+  destination: _commands/ip-route
+
+- name: Firewall rules
+  type: shell
+  command: iptables -L -v -n
+  destination: _commands/iptables
+
+- name: Listening ports
+  type: shell
+  command: ss -tulpn
+  destination: _commands/ss-listening
+
+- name: Network connections
+  type: shell
+  command: ss -tupn
+  destination: _commands/ss-connections
+
+- name: DNS configuration
+  type: file
+  source: /etc/resolv.conf
+  destination: etc/resolv.conf
+```
+
+## Docker/Container Diagnostics
+
+Collect information about Docker containers:
+
+```yaml
+---
+- name: Docker daemon info
+  type: shell
+  command: docker info
+  destination: _commands/docker-info
+
+- name: Running containers
+  type: shell
+  command: docker ps -a
+  destination: _commands/docker-ps
+
+- name: Docker images
+  type: shell
+  command: docker images
+  destination: _commands/docker-images
+
+- name: Docker networks
+  type: shell
+  command: docker network ls
+  destination: _commands/docker-network-ls
+
+- name: Docker configuration
+  type: directory
+  source: /etc/docker
+  destination: etc/docker
+
+- name: Container details
+  type: shell_emitter
+  command: |
+    for container in `docker ps --all --format '{{ .Names }}'`
+    do
+      echo "
+    - name: Inspect ${container}
+      type: shell
+      command: docker inspect ${container}
+      destination: _commands/docker/${container}/inspect
+
+    - name: Logs for ${container}
+      type: shell
+      command: docker logs --tail 2000 ${container}
+      destination: _commands/docker/${container}/logs
+    "
+    done
+```
+
+## Kubernetes Diagnostics
+
+Collect information from a Kubernetes node:
+
+```yaml
+---
+- name: Kubectl version
+  type: shell
+  command: kubectl version
+  destination: _commands/kubectl-version
+
+- name: Node status
+  type: shell
+  command: kubectl get nodes -o wide
+  destination: _commands/nodes
+
+- name: All pods
+  type: shell
+  command: kubectl get pods --all-namespaces -o wide
+  destination: _commands/pods-all
+
+- name: Pod details
+  type: shell_emitter
+  command: |
+    kubectl get pods --all-namespaces -o jsonpath='{range .items[*]}{.metadata.namespace}/{.metadata.name}{"\n"}{end}' | while read pod
+    do
+      ns=$(echo $pod | cut -d/ -f1)
+      name=$(echo $pod | cut -d/ -f2)
+      echo "
+    - name: Describe pod ${name} in ${ns}
+      type: shell
+      command: kubectl describe pod ${name} -n ${ns}
+      destination: _commands/k8s/${ns}/${name}/describe
+
+    - name: Logs for ${name} in ${ns}
+      type: shell
+      command: kubectl logs ${name} -n ${ns} --tail=1000
+      destination: _commands/k8s/${ns}/${name}/logs
+    "
+    done
+
+- name: Kubelet logs
+  type: shell
+  command: journalctl -u kubelet --no-pager -n 1000
+  destination: _commands/journalctl-kubelet
+```
+
+## Systemd Service Diagnostics
+
+Collect information about systemd services:
+
+```yaml
+---
+- name: Systemd status
+  type: shell
+  command: systemctl status
+  destination: _commands/systemctl-status
+
+- name: Failed units
+  type: shell
+  command: systemctl --failed
+  destination: _commands/systemctl-failed
+
+- name: All services
+  type: shell
+  command: systemctl list-units --type=service
+  destination: _commands/services
+
+- name: Service logs
+  type: shell_emitter
+  command: |
+    for service in nginx apache2 mysql postgresql docker
+    do
+      echo "
+    - name: Journal for ${service}
+      type: shell
+      command: journalctl -u ${service} --no-pager -n 500
+      destination: _commands/journalctl/${service}
+    "
+    done
+```
+
+## Application-Specific Collection
+
+Example for a custom application with its own log directory:
+
+```yaml
+---
+- name: Application configuration
+  type: directory
+  source: /etc/myapp
+  destination: etc/myapp
+
+- name: Application logs
+  type: directory
+  source: /var/log/myapp
+  destination: var/log/myapp
+  exclude: ".*\\.gz$"  # Skip compressed old logs
+
+- name: Application data (excluding large files)
+  type: directory
+  source: /var/lib/myapp
+  destination: var/lib/myapp
+  exclude: "(cache|tmp|.*\\.db$)"
+
+- name: Application status
+  type: shell
+  command: myapp-cli status
+  destination: _commands/myapp-status
+
+- name: Application health check
+  type: shell
+  command: curl -s http://localhost:8080/health
+  destination: _commands/myapp-health
+```
+
+## Built-in Examples
+
+Clingwrap ships with two comprehensive examples.
+
+### Shaken Fist CI Failure
+
+Use with:
+
+```bash
+clingwrap gather --target shakenfist-ci-failure --output debug.zip
+```
+
+This collects:
+
+- System information (kernel, OS, hostname)
+- Package lists (dpkg, pip)
+- Configuration directories (Apache, AppArmor, Shaken Fist)
+- Service logs (etcd, libvirtd, systemd units)
+- Network diagnostics including namespaces
+- VXLAN network details
+- Libvirt VM list
+- Shaken Fist instances and events (excluding disk images)
+- etcd database contents
+- Docker information
+
+### OpenStack Kolla-Ansible
+
+Use with:
+
+```bash
+clingwrap gather --target openstack-kolla-ansible --output debug.zip
+```
+
+This collects:
+
+- System information (kernel, OS, hostname)
+- Kolla configuration
+- Package lists (dpkg, rpm, pip)
+- Systemd status
+- Syslog files
+- Kolla-Ansible logs
+- Running processes
+- Docker containers with inspection and logs
+- Container pip package lists
+- Package manager configurations
+
+## Running Examples
+
+### Using a Built-in Example
+
+```bash
+clingwrap gather --target shakenfist-ci-failure --output debug.zip
+```
+
+### Using a Custom Configuration File
+
+```bash
+clingwrap gather --target /path/to/myconfig.cwd --output debug.zip
+```
+
+### Using Stdin
+
+```bash
+cat myconfig.cwd | clingwrap gather --output debug.zip
+```
+
+### With Elevated Privileges
+
+Many diagnostics require root access:
+
+```bash
+sudo clingwrap gather --target myconfig.cwd --output debug.zip
+```

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,89 @@
+# Clingwrap Documentation
+
+Clingwrap is a debugging information collection tool that bundles system state
+data into a zip file for later analysis. Originally built for the
+[Shaken Fist](https://shakenfist.com) project, it is a general-purpose tool
+useful for any system debugging scenario.
+
+## Key Features
+
+- **Rapid collection**: Quickly gather comprehensive system diagnostics
+- **Single output**: All data bundled into one compressed ZIP file for easy
+  distribution
+- **Flexible configuration**: YAML-based configuration files define what to
+  collect
+- **Multiple command types**: Support for files, directories, shell commands,
+  and dynamic job generation
+- **CI/CD friendly**: Designed for use in automated testing pipelines to
+  capture failure diagnostics
+
+## Documentation Index
+
+### Getting Started
+
+- [Installation](installation.md) - How to install clingwrap
+- [Configuration](configuration.md) - Configuration file format and structure
+- [Examples](examples.md) - Example configurations and use cases
+
+### Reference
+
+- [Command Types](command-types.md) - Detailed documentation of all command
+  types
+
+## Quick Start
+
+Install clingwrap:
+
+```bash
+pip install clingwrap
+```
+
+Run with a built-in example configuration:
+
+```bash
+clingwrap gather --target shakenfist-ci-failure --output debug.zip
+```
+
+Or use your own configuration file:
+
+```bash
+clingwrap gather --target /path/to/config.cwd --output debug.zip
+```
+
+## Command Line Interface
+
+The main command is `clingwrap gather` with the following options:
+
+| Option | Required | Description |
+|--------|----------|-------------|
+| `--target` | No | Configuration file path or built-in example name |
+| `--output` | Yes | Output ZIP file path |
+
+If `--target` is omitted, clingwrap reads configuration from stdin.
+
+## Output Format
+
+Clingwrap produces a single ZIP file containing:
+
+- Collected files and directories (preserving original paths)
+- Shell command outputs (stored in `_commands/` directory)
+- `clingwrap.log` - Execution log with timestamps and job tracking
+
+## Built-in Examples
+
+Clingwrap ships with example configurations that can be used by name:
+
+| Name | Description |
+|------|-------------|
+| `shakenfist-ci-failure` | Comprehensive collection for Shaken Fist CI failures |
+| `openstack-kolla-ansible` | Collection for OpenStack Kolla-Ansible deployments |
+
+## External Resources
+
+- [GitHub Repository](https://github.com/shakenfist/clingwrap)
+- [Bug Tracker](https://github.com/shakenfist/clingwrap/issues)
+- [Shaken Fist Project](https://shakenfist.com)
+
+## License
+
+Clingwrap is licensed under the Apache 2.0 license.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,0 +1,86 @@
+# Installation
+
+## Requirements
+
+- Python 3.7 or later
+- pip (Python package installer)
+
+## Installing from PyPI
+
+The simplest way to install clingwrap is from PyPI:
+
+```bash
+pip install clingwrap
+```
+
+## Installing from Source
+
+To install from source, clone the repository and install using pip:
+
+```bash
+git clone https://github.com/shakenfist/clingwrap.git
+cd clingwrap
+pip install .
+```
+
+For development installations with editable mode:
+
+```bash
+pip install -e .
+```
+
+## Dependencies
+
+Clingwrap has the following runtime dependencies (installed automatically):
+
+| Package | License | Purpose |
+|---------|---------|---------|
+| `oslo.concurrency` | Apache 2.0 | Process execution with timeouts |
+| `click` (>=7.1.1) | BSD | Command-line interface framework |
+| `pyyaml` | MIT | YAML configuration file parsing |
+| `shakenfist-utilities` | Apache 2.0 | Shared utility functions |
+
+## Development Dependencies
+
+For running tests and development work, install the test dependencies:
+
+```bash
+pip install clingwrap[test]
+```
+
+This installs additional packages:
+
+| Package | Purpose |
+|---------|---------|
+| `coverage` | Code coverage analysis |
+| `testtools` | Test utilities |
+| `mock` | Mocking library |
+| `stestr` | Test runner |
+| `tox` | Test automation |
+| `flake8` | Code linting |
+
+## Verifying Installation
+
+After installation, verify clingwrap is available:
+
+```bash
+clingwrap --help
+```
+
+You should see output showing the available commands and options.
+
+## Permissions
+
+Clingwrap collects system information, which may require elevated privileges
+depending on what you want to collect. Common scenarios requiring root or sudo:
+
+- Reading system logs (`/var/log/syslog`)
+- Accessing container information (`docker` commands)
+- Reading protected configuration files
+- Executing privileged commands (e.g., `iptables`, `etcdctl`)
+
+Run with appropriate permissions based on your collection requirements:
+
+```bash
+sudo clingwrap gather --target myconfig.cwd --output debug.zip
+```


### PR DESCRIPTION
Create a docs/ directory with comprehensive documentation that can be published to the web, similar to the kerbside project. Documentation includes:

- index.md: Main entry point with overview and navigation
- installation.md: Installation instructions and dependencies
- configuration.md: Configuration file format and best practices
- command-types.md: Detailed reference for all four command types
- examples.md: Example configurations for various use cases

Also add AGENTS.md for AI agent instructions and ARCHITECTURE.md describing the system architecture. Update README.md with a quick start section and link to the new documentation.

Prompt: Let's work in shakenfist/clingwrap. Similarly to shakenfist/kerbside, I'd like to generate a docs/ directory of documentation about clingwrap as markdown that can then be published to the web.